### PR TITLE
Kristofer patch 1, fixes #202 #203

### DIFF
--- a/src/pages/contribute/components/CSTKScore.js
+++ b/src/pages/contribute/components/CSTKScore.js
@@ -62,24 +62,31 @@ const Comp = ({ balances, effectiveBalance, getBalancesFor, getEffectiveBalances
       {effectiveBalance === 0 && (
         <div className="subtitle mb-05">You haven't paid your membership dues yet</div>
       )}
-      <div className="is-flex is-align-items-center">
-        <div className="subtitle mb-05" style={{ marginBottom: '0px' }}>
+      <div className="is-flex is-align-items-center cstk-score">
+        <div className="subtitle cstk-score-text">
           <span>Don't see you CSTK score in Metamask? Add your tokens to make them visible.</span>
         </div>
         <div
-          className="subtitle mb-05"
+          className="subtitle"
           style={{
             color: '#1BDD9D',
             cursor: 'pointer',
             fontSize: '16px',
-            whiteSpace: 'nowrap',
             marginLeft: '14px',
           }}
           onClick={addCSTK}
         >
-          <span style={{ padding: '4px', border: 'solid 1px #1BDD9D', borderRadius: '2px' }}>
+          <div
+            className="cstk-button"
+            style={{
+              padding: '4px',
+              border: 'solid 1px #1BDD9D',
+              borderRadius: '2px',
+              whiteSpace: 'nowrap',
+            }}
+          >
             + Add to Metamask
-          </span>
+          </div>
         </div>
       </div>
     </>

--- a/src/pages/contribute/components/ContributeForm.js
+++ b/src/pages/contribute/components/ContributeForm.js
@@ -12,7 +12,7 @@ import './DonateModal.sass';
 
 const config = require('../../../config');
 
-const Comp = ({ onClose, balances, effectiveBalance, getBalancesFor, getEffectiveBalancesFor }) => {
+const Comp = ({ onClose, balances, effectiveBalance, getBalancesFor }) => {
   const { isReady, address } = useContext(OnboardContext);
   const [amountDAI, setAmountDAI] = React.useState(config.defaultContribution);
   const [amountCSTK, setAmountCSTK] = React.useState(0);
@@ -93,12 +93,6 @@ const Comp = ({ onClose, balances, effectiveBalance, getBalancesFor, getEffectiv
         setAmountDAI(amountDAIFloat);
         setAmountCSTK(0);
       } else if (balances && balances[address]) {
-        const dai = balances[address].find(b => b.symbol === 'DAI');
-        if (dai.balance >= 450 && dai.balance <= 900) setAmountDAI(dai.balance);
-        else if (dai.balance < 450) {
-          setAmountDAI(450);
-          setShowApplyToScholarshipTooltip(true);
-        }
         const cstk = balances[address].find(b => b.symbol === 'CSTK');
         const myBalance = new BigNumber(cstk.balance || '0');
         // Work only for the first year (dues = 450 DAI = 1125 CSTK)
@@ -139,15 +133,22 @@ const Comp = ({ onClose, balances, effectiveBalance, getBalancesFor, getEffectiv
     } catch (e) {
       // console.error(e);
     }
-  }, [
-    amountDAI,
-    balances,
-    address,
-    getBalancesFor,
-    effectiveBalance,
-    getEffectiveBalancesFor,
-    hasPaidDues,
-  ]);
+  }, [amountDAI, balances, address, getBalancesFor, effectiveBalance, hasPaidDues]);
+
+  React.useEffect(() => {
+    try {
+      if (balances && balances[address]) {
+        const dai = balances[address].find(b => b.symbol === 'DAI');
+        if (dai.balance >= 450 && dai.balance <= 900) setAmountDAI(dai.balance);
+        else if (dai.balance < 450) {
+          setAmountDAI(450);
+          setShowApplyToScholarshipTooltip(true);
+        }
+      }
+    } catch (e) {
+      // console.error(e);
+    }
+  }, [balances, address]);
 
   React.useEffect(() => {
     setDonationButtonEnabled((hasPaidDues && amountDAI >= 0) || amountCSTK > 0);

--- a/src/pages/contribute/components/ContributeForm.js
+++ b/src/pages/contribute/components/ContributeForm.js
@@ -116,7 +116,6 @@ const Comp = ({ onClose, balances, effectiveBalance, getBalancesFor }) => {
         if (dai.balance >= 450 && dai.balance <= 900) setAmountDAI(dai.balance);
         else if (dai.balance < 450) {
           setAmountDAI(450);
-          setShowApplyToScholarshipTooltip(true);
         }
       }
     } catch (e) {

--- a/src/sass/style.sass
+++ b/src/sass/style.sass
@@ -122,3 +122,16 @@ $tooltip-arrow-size: 8px
   white-space: nowrap
   overflow: hidden
   text-overflow: ellipsis
+
+.cstk-score
+  flex-direction: row
+
+.cstk-score-text
+  margin-bottom: 0 !important
+
+@media (min-width: $tablet) and (max-width: $fullhd)
+  .cstk-score
+    flex-direction: column
+
+  .cstk-score-text
+    padding-bottom: 1rem


### PR DESCRIPTION
Patches to fix #202 and #203. 

#202
Fixes the responsive issue with the "Add to metamask" button

From: 
![Skärmavbild 2021-03-11 kl  13 38 10](https://user-images.githubusercontent.com/9698363/110792726-06fd1a80-8274-11eb-9d2f-2307bf9b7f74.png)

To:
![Skärmavbild 2021-03-11 kl  13 38 21](https://user-images.githubusercontent.com/9698363/110792761-13817300-8274-11eb-85a3-baaa93d8ed1f.png)

#203 
I created a new `React.useEffect` focusing only on `balances` and `address` to prevent the DAI amount from being reset when user enters amount in input field.

ps. Possibly should have done two PRs, on for each fix. But … I was to fast and know to little about git to split after commits have been made to the same branch.