### PR TITLE
Text adjustments after paying dues

### DIFF
--- a/src/pages/contribute/components/Contribute.js
+++ b/src/pages/contribute/components/Contribute.js
@@ -170,7 +170,7 @@ const Comp = ({
                           }}
                           className="button is-success is-medium"
                         >
-                          Pay Membership Dues
+                          {effectiveBalance > 0 ? 'Pay Additional Dues' : 'Pay Membership Dues'}
                         </button>
                       )}
                     </span>
@@ -212,7 +212,18 @@ const Comp = ({
 
               <br />
               <p>
-                Membership dues are paid with DAI. You can acquire DAI on{' '}
+                {effectiveBalance > 0 ? (
+                  <>
+                    <span className="icon has-text-success">
+                      <i className="fas fa-check-circle" />
+                    </span>
+                    Your membership dues are paid. By paying more membership dues you will further
+                    help the mission of the organization.
+                  </>
+                ) : (
+                  'Membership dues are paid with DAI.'
+                )}{' '}
+                You can acquire DAI on{' '}
                 <a
                   className="exchange"
                   rel="noopener noreferrer"

--- a/src/pages/contribute/components/Welcome.js
+++ b/src/pages/contribute/components/Welcome.js
@@ -4,7 +4,7 @@ import WalletView from './WalletView';
 import Contribute from './Contribute';
 import CSTKScore from './CSTKScore';
 
-const Comp = () => {
+const Comp = ({ effectiveBalance }) => {
   return (
     <>
       <section className="section has-text-left">
@@ -13,9 +13,11 @@ const Comp = () => {
             <article className="is-child notification is-primary">
               <WalletView />
             </article>
-            <article className="is-child notification is-primary">
-              <CSTKScore />
-            </article>
+            {effectiveBalance > 0 ? null : (
+              <article className="is-child notification is-primary">
+                <CSTKScore />
+              </article>
+            )}
           </div>
           <div className="tile is-parent">
             <Contribute />
@@ -26,8 +28,10 @@ const Comp = () => {
   );
 };
 
-const mapStateToProps = () => {
-  return {};
+const mapStateToProps = state => {
+  return {
+    effectiveBalance: state.effectiveBalance,
+  };
 };
 
 const mapDispatchToProps = dispatch => {


### PR DESCRIPTION
This closes #224. Screen now looks like this after membership dues have been paid:

![image](https://user-images.githubusercontent.com/9698363/112613526-7cdeb580-8e20-11eb-8c7d-b300f31468eb.png)
